### PR TITLE
Update package references to Rx 2.2.2.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -9,7 +9,7 @@ open Fake.MSBuild
 
 (* properties *)
 let projectName = "FSharp.Reactive"
-let version = if isLocalBuild then "2.1." + System.DateTime.UtcNow.ToString("yMMdd") else buildVersion
+let version = if isLocalBuild then "2.2." + System.DateTime.UtcNow.ToString("yMMdd") else buildVersion
 let projectSummary = "A F#-friendly wrapper for the Reactive Extensions."
 let projectDescription = "A F#-friendly wrapper for the Reactive Extensions."
 let authors = ["Ryan Riley"; "Steffen Forkmann"]
@@ -89,7 +89,7 @@ Target "BuildNuGet" (fun _ ->
             Description = projectDescription
             Version = version
             OutputPath = nugetDir
-            Dependencies = ["Rx-Linq", rxVersion]
+            Dependencies = ["Rx-Core", rxVersion; "Rx-Interfaces", rxVersion; "Rx-Linq", rxVersion]
             AccessKey = getBuildParamOrDefault "nugetkey" ""
             ToolPath = nugetPath
             Publish = hasBuildParam "nugetkey" })

--- a/src/FSharp.Reactive.fsproj
+++ b/src/FSharp.Reactive.fsproj
@@ -52,15 +52,15 @@
       <HintPath>..\lib\FSharp\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
-      <HintPath>..\packages\Rx-Core.2.0.21114\lib\Net40\System.Reactive.Core.dll</HintPath>
+      <HintPath>..\packages\Rx-Core.2.2.2\lib\Net40\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Reactive.Interfaces">
-      <HintPath>..\packages\Rx-Interfaces.2.0.21114\lib\Net40\System.Reactive.Interfaces.dll</HintPath>
+      <HintPath>..\packages\Rx-Interfaces.2.2.2\lib\Net40\System.Reactive.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Reactive.Linq">
-      <HintPath>..\packages\Rx-Linq.2.0.21114\lib\Net40\System.Reactive.Linq.dll</HintPath>
+      <HintPath>..\packages\Rx-Linq.2.2.2\lib\Net40\System.Reactive.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rx-Core" version="2.0.21114" targetFramework="net40" />
-  <package id="Rx-Interfaces" version="2.0.21114" targetFramework="net40" />
-  <package id="Rx-Linq" version="2.0.21114" targetFramework="net40" />
+  <package id="Rx-Core" version="2.2.2" targetFramework="net40" />
+  <package id="Rx-Interfaces" version="2.2.2" targetFramework="net40" />
+  <package id="Rx-Linq" version="2.2.2" targetFramework="net40" />
 </packages>

--- a/tests/FSharp.Reactive.Tests.fsproj
+++ b/tests/FSharp.Reactive.Tests.fsproj
@@ -47,7 +47,7 @@
       <HintPath>..\lib\FSharp\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Reactive.Testing">
-      <HintPath>..\packages\Rx-Testing.2.0.21114\lib\Net40-Full\Microsoft.Reactive.Testing.dll</HintPath>
+      <HintPath>..\packages\Rx-Testing.2.2.2\lib\Net40-Full\Microsoft.Reactive.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
@@ -55,17 +55,17 @@
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.0.12054\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Reactive.Core">
-      <HintPath>..\packages\Rx-Core.2.0.21114\lib\Net40\System.Reactive.Core.dll</HintPath>
+      <HintPath>..\packages\Rx-Core.2.2.2\lib\Net40\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Reactive.Interfaces">
-      <HintPath>..\packages\Rx-Interfaces.2.0.21114\lib\Net40\System.Reactive.Interfaces.dll</HintPath>
+      <HintPath>..\packages\Rx-Interfaces.2.2.2\lib\Net40\System.Reactive.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <ProjectReference Include="..\src\FSharp.Reactive.fsproj">
@@ -74,11 +74,11 @@
       <Private>True</Private>
     </ProjectReference>
     <Reference Include="System.Reactive.Linq">
-      <HintPath>..\packages\Rx-Linq.2.0.21114\lib\Net40\System.Reactive.Linq.dll</HintPath>
+      <HintPath>..\packages\Rx-Linq.2.2.2\lib\Net40\System.Reactive.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Reactive.PlatformServices">
-      <HintPath>..\packages\Rx-PlatformServices.2.0.21114\lib\Net40\System.Reactive.PlatformServices.dll</HintPath>
+      <HintPath>..\packages\Rx-PlatformServices.2.2.2\lib\Net40\System.Reactive.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.0.12054" />
-  <package id="NUnit.Runners" version="2.6.0.12051" />
-  <package id="Rx-Core" version="2.0.21114" targetFramework="net40" />
-  <package id="Rx-Interfaces" version="2.0.21114" targetFramework="net40" />
-  <package id="Rx-Linq" version="2.0.21114" targetFramework="net40" />
-  <package id="Rx-Main" version="2.0.21114" targetFramework="net40" />
-  <package id="Rx-PlatformServices" version="2.0.21114" targetFramework="net40" />
-  <package id="Rx-Testing" version="2.0.21114" targetFramework="net40" />
+  <package id="NUnit" version="2.6.3" />
+  <package id="NUnit.Runners" version="2.6.3" />
+  <package id="Rx-Core" version="2.2.2" targetFramework="net40" />
+  <package id="Rx-Interfaces" version="2.2.2" targetFramework="net40" />
+  <package id="Rx-Linq" version="2.2.2" targetFramework="net40" />
+  <package id="Rx-Main" version="2.2.2" targetFramework="net40" />
+  <package id="Rx-PlatformServices" version="2.2.2" targetFramework="net40" />
+  <package id="Rx-Testing" version="2.2.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
I've updated the package references to the latest version of Rx (v2.2.2). I've also updated the NUnit and NUnit.Runners packages (used by the test project) to v2.6.3, which contains some bugfixes to allow unit tests to run correctly under Mono.
