### PR TITLE
The definition of Observable.zip is incorrect as it should allow the fir...

### DIFF
--- a/src/Observable.fs
+++ b/src/Observable.fs
@@ -131,7 +131,7 @@ module Observable =
     let both second first = Observable.And(first, second)
 
     /// Merges two observable sequences into one observable sequence
-    let zip (second: IObservable<'T>) (first: IObservable<'T>) =
+    let zip (second: IObservable<'U>) (first: IObservable<'T>) =
         let inner a b = a, b
         Observable.Zip(first, second, Func<_,_,_> inner)
 

--- a/tests/ObservableSpecs.fs
+++ b/tests/ObservableSpecs.fs
@@ -98,3 +98,12 @@ let ``Test should show the stack overflow is fixed with Rx 2 beta``() =
         g 5 |> Observable.subscribe ignore ignore ignore |> ignore
     Assert.DoesNotThrow(TestDelegate(fun () -> test()))
 
+[<Test>]
+let ``Zipping two observable sequences of different types creates a single zipped observable`` =
+   let obs1 = Observable.Return 1
+   let obs2 = Observable.Return "A"
+   let zipped = obs1 |> Observable.zip obs2
+   let result = zipped |> Observable.First
+   let expected = ( 1, "A" )
+
+   Assert.That(result, Is.EqualTo(expected))


### PR DESCRIPTION
...st observable to be of a different type to the second observable
