### PR TITLE
Updated FSharp.Compiler.Service nuget to 0.0.62

### DIFF
--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -31,7 +31,7 @@ let info =
 
 #I "../../packages/FSharp.Formatting.2.4.25/lib/net40"
 #I "../../packages/RazorEngine.3.3.0/lib/net40"
-#I "../../packages/FSharp.Compiler.Service.0.0.36/lib/net40"
+#I "../../packages/FSharp.Compiler.Service.0.0.62/lib/net40"
 #r "../../packages/Microsoft.AspNet.Razor.2.0.30506.0/lib/net40/System.Web.Razor.dll"
 #r "../../packages/FAKE/tools/NuGet.Core.dll"
 #r "../../packages/FAKE/tools/FakeLib.dll"

--- a/docs/tools/packages.config
+++ b/docs/tools/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FSharp.Formatting" version="2.4.25" targetFramework="net45" />
-  <package id="FSharp.Compiler.Service" version="0.0.36" targetFramework="net45" /> 
+  <package id="FSharp.Compiler.Service" version="0.0.62" targetFramework="net45" /> 
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="RazorEngine" version="3.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The version of FSharp.Formatting being used needs a newer (0.0.59+) version of FSharp.Compiler.Service.

The docs still fail, but they get a lot further than they did for me before.
