### PR TITLE
Change Observable.combineLatest signature to return a tuple

### DIFF
--- a/src/Observable.fs
+++ b/src/Observable.fs
@@ -318,10 +318,10 @@ module Observable =
     // #region CombineLatest Functions
 
 
-    /// Merges the specified observable sequences into one observable sequence by  applying the map
-    /// whenever any of the observable sequences produces an element.
-    let combineLatest ( map : 'T1 -> 'T2 -> 'Result  ) ( source1 : IObservable<'T1> ) ( source2 : IObservable<'T2> ) =
-        Observable.CombineLatest(source1, source2, Func<'T1, 'T2 ,'Result> map )
+    /// Merges the specified observable sequences into one observable sequence
+    /// whenever either of the observable sequences produces an element.
+    let combineLatest ( source1 : IObservable<'T1> ) ( source2 : IObservable<'T2> ) =
+        Observable.CombineLatest(source1, source2, fun t1 t2 -> (t1, t2) )
 
     /// Merges the specified observable sequences into one observable sequence by 
     /// emmiting a list with the latest source elements of whenever any of the 

--- a/tests/ObservableSpecs.fs
+++ b/tests/ObservableSpecs.fs
@@ -271,8 +271,9 @@ let ``combineLatest calls map function with pairs of latest values``() =
     let result   = ResizeArray()
     use obs1     = new Subject<int>()
     use obs2     = new Subject<int>()
-    let map x y  = x + (y / 2)
-    Observable.combineLatest map obs1 obs2
+    let map (x, y)  = x + (y / 2)
+    Observable.combineLatest obs1 obs2
+        |> Observable.map map
         |> Observable.subscribe(result.Add) 
         |> ignore
 


### PR DESCRIPTION
Change Observable.combineLatest signature to return a tuple and not require a map function.