### PR TITLE
fix groupByCompare to use correct GroupBy overload with comparer

### DIFF
--- a/src/FSharp.Control.Reactive/Observable.fs
+++ b/src/FSharp.Control.Reactive/Observable.fs
@@ -748,7 +748,7 @@ module Observable =
     let groupByCompare ( keySelector  )
                         ( comparer    : IEqualityComparer<_> )
                         ( source      : IObservable<_>    ) : IObservable<IGroupedObservable<_,_>> =
-        Observable.GroupBy( source, Func<_,_> keySelector, keySelector )
+        Observable.GroupBy( source, Func<_,_> keySelector, comparer )
 
 
     /// Groups the elements of an observable sequence and selects the resulting elements by using a specified function.


### PR DESCRIPTION
Fixes the groupByCompare so a custom equality comparer can be used. Nice to have since in F# you commonly want to use HashIdentity.Structural as your comparer.