### PR TITLE
Fix warnings in source and test project

### DIFF
--- a/src/FSharp.Control.Reactive/Observable.fs
+++ b/src/FSharp.Control.Reactive/Observable.fs
@@ -773,7 +773,7 @@ module Observable =
     /// Converts a .NET event to an observable sequence, using a supplied event delegate type on a specified scheduler. 
     /// Each event invocation is surfaced through an OnNext message in the resulting sequence.
     let fromEventHandlerOn (scheduler:IScheduler) addHandler removeHandler =
-        Observable.FromEventPattern<'TEventArgs> (
+        Observable.FromEventPattern<'EventArgs> (
             Action<EventHandler<'EventArgs>> addHandler, 
             Action<EventHandler<'EventArgs>> removeHandler, 
             scheduler)
@@ -798,7 +798,7 @@ module Observable =
             initialState, 
             Func<'State, bool> condition, 
             Func<'State, 'State> iterator, 
-            Func<'TState, 'TResult> resultMap, 
+            Func<'State, 'TResult> resultMap, 
             scheduler)
       
 

--- a/tests/EmitsSpecs.fs
+++ b/tests/EmitsSpecs.fs
@@ -5,6 +5,8 @@ open FsCheck
 open FSharp.Control.Reactive
 open FSharp.Control.Reactive.Testing
 
+#nowarn "988"
+
 [<TestFixture>]
 type EmitTest () = 
     
@@ -54,4 +56,4 @@ type EmitTest () =
                     |> TestSchedule.subscribeTestObserverStart sch
                     |> TestObserver.nexts = TestNotification.mapNexts f ms
 
-        
+


### PR DESCRIPTION
The Observable module had some warnings about 'less generic' for the
some of the scheduler functions because of missue of generics.
The specs for test notifications had a warning about no
entry-point/nothing-to-execute; which is now supressed because it's a
`[TestFixture]`.