### PR TITLE
Add observable preparation for the IO package

### DIFF
--- a/src/FSharp.Control.Reactive/Disposable.fs
+++ b/src/FSharp.Control.Reactive/Disposable.fs
@@ -53,6 +53,8 @@ module Disposable =
         d.Disposable <- indirection
         indirection.Disposable <- disposableFactory ()
 
+    let setInnerDisposalOf (d : SerialDisposable) x = d.Disposable <- x
+
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module WaitHandle =
     open System.Threading

--- a/src/FSharp.Control.Reactive/FSharp.Control.Reactive.fsproj
+++ b/src/FSharp.Control.Reactive/FSharp.Control.Reactive.fsproj
@@ -3,11 +3,11 @@
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="paket.references" />
     <Compile Include="Disposable.fs" />
-    <Compile Include="Observable.fs" />
     <Compile Include="Scheduler.fs" />
     <Compile Include="Subject.fs" />
-    <None Include="paket.references" />
+    <Compile Include="Observable.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
Some extra combinators is used in the new awaiting IO pacakge I'm
working on.

It seemed reasonable to first check with you if you're all agree on these before moving instead of creating a giant PR.

These operators are added together with some round-trip tests:
- `poll`: periodically repeats a sequence
- `choose`: selects only emits returning `Some`
- `switchMap`: projects each source value to an Observable which is merged in the output Observable, emitting values only from the most recently projected Observable.
- `exhaustMap`: projects each source value to an Observable which is merged in the output Observable only if the previous projected Observable has completed.
- `serve`: concurrently invokes the specified factory to create observables as fast and often as possible and subscribes to all of them up to the default maximum concurrency.
- `consume`: generates a sequence using the producer/consumer pattern.

Some of them are inspired by the [Rxx](https://github.com/RxDave/Rxx/) package (like the `serve` and `consume`). `switchMap` and `exhaustMap` are ports form **RxJs**.

Love to hear your opinion.
Let me know if I should test something else, more, ... or any other suggestion!