### PR TITLE
Fix of the choose pull request.

### DIFF
--- a/src/FSharp.Control.Reactive/Observable.fs
+++ b/src/FSharp.Control.Reactive/Observable.fs
@@ -2350,7 +2350,7 @@ module Observable =
     let choose f source =
         Observable.Create (fun (o : IObserver<_>) ->
             subscribeSafeWithCallbacks 
-                (fun x -> try f x |> Option.iter o.OnNext with ex -> o.OnError ex)
+                (fun x -> Option.iter o.OnNext (try f x with ex -> o.OnError ex; None))
                 o.OnError
                 o.OnCompleted
                 source)


### PR DESCRIPTION
Changed the implementation of choose again so as to allow the call to OnNext to be in tail position.

This is one of the rare cases where due a return being used in the catch branch, it is not actually possible to get the same efficiency in F# as it would be in C#. It is good that `choose` uses options intrinsically so it should be close to optimal.