### PR TITLE
A workaround for a bug in F# compiler (dotnet/fsharp#9616)

### DIFF
--- a/src/FSharp.Control.Reactive/Observable.fs
+++ b/src/FSharp.Control.Reactive/Observable.fs
@@ -126,7 +126,9 @@ module Observable =
     type Observable with
         /// Creates an observable sequence from the specified Subscribe method implementation.
         static member Create (subscribe: IObserver<'T> -> unit -> unit) =
-            let subscribe o = Action(subscribe o)
+            let subscribe o = 
+                let m = subscribe o
+                Action(m)
             Observable.Create(subscribe)
 
         /// Creates an observable sequence from the specified asynchronous Subscribe method implementation.


### PR DESCRIPTION
The `Observable.Create` method did not work for me, and after some investigation, I found that it's [a problem with the compiler](https://github.com/dotnet/fsharp/issues/9616). I hope it will get solved soon, but, in the meantime, you may consider merging this PR so the method will work properly.

Thank you for the excellent library.