### PR TITLE
Lower requires FSharp.Core and clean out TFMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: csharp
 
-mono: 5.2.0
 dotnet : 5.0.100
 
-install:
-  - mozroots --import --sync
-  - export FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.5/
 matrix:
   include:
     - os: linux

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,7 +4,7 @@ redirects: on
 storage: none
 
 nuget fparsec
-nuget FSharp.Core
+nuget FSharp.Core >= 4.7.2
 nuget System.Reactive ~> 5.0
 nuget Microsoft.Reactive.Testing ~> 5.0
 nuget Microsoft.NET.Test.Sdk

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ryan Riley;Steffen Forkmann;Jared Hester</Authors>
     <Summary>A F#-friendly wrapper for the Reactive Extensions.</Summary>

--- a/src/FSharp.Control.Reactive.Testing/FSharp.Control.Reactive.Testing.fsproj
+++ b/src/FSharp.Control.Reactive.Testing/FSharp.Control.Reactive.Testing.fsproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="paket.references" />
     <Compile Include="TestNotifications.fs" />

--- a/src/FSharp.Control.Reactive/FSharp.Control.Reactive.fsproj
+++ b/src/FSharp.Control.Reactive/FSharp.Control.Reactive.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+     <TargetFrameworks>net472;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <None Include="paket.references" />

--- a/src/FSharp.Control.Reactive/FSharp.Control.Reactive.fsproj
+++ b/src/FSharp.Control.Reactive/FSharp.Control.Reactive.fsproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="paket.references" />
     <Compile Include="Disposable.fs" />


### PR DESCRIPTION
Fixes https://github.com/fsprojects/FSharp.Control.Reactive/issues/160 

Also clears out what _appears_ to be redundant TFM usage (it really should not be needed, since there are no conditional defines for each target). and some stuff in the travis build.